### PR TITLE
Update the regular expression example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For the sake of performance, we limit the number of search results if there are 
 ## Regular Expression and Exact Matches Support
 Whenever the user does need an exact match, just use double quotes around a word or words. For example, you can search for `"airplane" flew` instead of `airplane flew`. This should be intuitive because that's how you would make your results exact in Google search. 
 
-You can search using regular expressions by surrounding your search text with `/`. For example, to look for 4-letter words that start with "d" and end with "e", type `/\sd[^\s]{2}e\s/`.
+You can search using regular expressions by surrounding your search text with `/`. For example, to look for 4-letter words that start with "d" and end with "e", type `/\bd[^\s]{2}e\b/`.
 
 ## Development
 


### PR DESCRIPTION
To showcase the use for regular expression search, the README suggests `/\sd[^\s]{2}e\s/` to find "4-letter words that start with _d_ and end with _e_''. But using space as delimiter would actually miss quite some instances of those words. I would replace it with `\b` which is word-boundary and handles start of sentence, commas, final period etc.

Example: a page containing the sentence

> dude paid a dime, got a dose.

would return no match with `/\sd[^\s]{2}e\s/` but would match _dude_, _dime_, and _dose_ with `/\bd[^\s]{2}e\b/`.